### PR TITLE
CTV-2208: fix midroll ad request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.0.1
+* Fix ad call so midroll ads are correctly fetched. A different ad from the preroll should be returned (currently, it's a Hilton branded campaign)
+
 ## v1.0.0
 * Initial implementation for reference channel demonstrating true[X] integration alongside client side ad insertion.

--- a/res/reference-app-streams.json
+++ b/res/reference-app-streams.json
@@ -55,7 +55,7 @@
                         "adParameters" : {
                             "user_id" : "test_html5_00005",
                             "placement_hash" : "74fca63c733f098340b0a70489035d683024440d",
-                            "vast_config_url" : "get.truex.com/74fca63c733f098340b0a70489035d683024440d/vast/config?asnw=&cpx_url=&dimension_2=0&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&network_user_id=test_roku_00005&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&stream_id=1&vdur=&vprn="
+                            "vast_config_url" : "get.truex.com/74fca63c733f098340b0a70489035d683024440d/vast/config?asnw=&cpx_url=&dimension_2=1&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&network_user_id=test_roku_00005&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&stream_id=1&vdur=&vprn="
                         }
                     },
                     {


### PR DESCRIPTION
Fixing the `dimension_2` ad request parameter to be `1` for the midroll pod. This enables our pod targeting to work for the different campaign to be used in this case (Hilton) as opposed to the same ad (NAR) being served again.

Manual testing